### PR TITLE
Clean up initial AST node implementations to match lecture examples

### DIFF
--- a/src/Node.ts
+++ b/src/Node.ts
@@ -1,4 +1,5 @@
 import Tokenizer from "./Tokenizer";
+import { ParserError } from "./errors/ParserError";
 
 export default abstract class Node {
   names: string[] = [];

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -1,10 +1,10 @@
 import Tokenizer from "./Tokenizer";
 
 export default abstract class Node {
-  let names = new Array<String>;
-  let types = new Map<String, String>;
-  let tokenizer = Tokenizer.getTokenizer();
-  abstract parse();
-  abstract evaluate();
-  abstract nameCheck();
+  names: string[] = [];
+  types: object = {};
+  abstract parse(tokenizer: Tokenizer): void;
+  abstract evaluate(): void;
+  abstract nameCheck(): void;
+  abstract typeCheck(): void;
 }

--- a/src/ast/Event.ts
+++ b/src/ast/Event.ts
@@ -1,27 +1,59 @@
-import DayOfWeek from "./DayOfWeek";
-import Date from "./Date";
+import Node from "../Node";
+import Tokenizer from "../Tokenizer";
 
-class Event extends CalTypes {
-  event: String;
-  calTypes: Array<CalTypes>;
+export default class Event extends Node {
+  title: string = "";
+  repeating: boolean = false;
+  daysOfWeek: string[] = [];
+  date: string = "";
+  allDay: boolean = false;
+  fromTime: string = "";
+  toTime: string = "";
+  location: string = "";
+  guests: string[] = [];
 
-  parse(): void {
-    while (!tokenizer.checkToken(";")) {
-      eventName = tokenizer.getNext();
-      if (tokenizer.checkToken("every") || tokenizer.checkToken("and")) {
-        calTypes.add(new DayOfWeek());
-      }
-      if (tokenizer.checkToken("on")) {
-        calTypes.add(new Date());
-      }
-      if (tokenizer.checkToken("from") || tokenizer.checkToken("to")) {
-        calTypes.add(new Time());
-      }
+  parse(tokenizer: Tokenizer): void {
+    this.title = tokenizer.getNext();
+    if (tokenizer.getAndCheckNext("every")) {
+      this.repeating = true;
+      do {
+        let dayOfWeek: string = tokenizer.getNext();
+        this.daysOfWeek.push(dayOfWeek);
+      } while (tokenizer.getAndCheckNext("and"))
+    } else if (tokenizer.getAndCheckNext("on")) {
+      this.repeating = false;
+      this.date = tokenizer.getNext();
     }
-    for (calType in CalTypes) {
-      calType.parse();
+
+    if (tokenizer.getAndCheckNext("all day")) {
+      this.allDay = true;
+    } else if (tokenizer.getAndCheckNext("from")) {
+      this.allDay = false;
+      this.fromTime = tokenizer.getNext();
+      tokenizer.getAndCheckNext("to");
+      this.toTime = tokenizer.getNext();
+    }
+
+    // stub for locations
+    if (tokenizer.getAndCheckNext("at")) {
+
+    }
+
+    // stub for guests
+    if (tokenizer.getAndCheckNext("with")) {
+
     }
   }
 
-  // TODO figure out what to do with typeCheck() and nameCheck() methods
+  evaluate(): void {
+    // TODO
+  }
+
+  nameCheck(): void {
+    // TODO
+  }
+
+  typeCheck(): void {
+    // TODO
+  }
 }

--- a/src/ast/Event.ts
+++ b/src/ast/Event.ts
@@ -3,6 +3,15 @@ import Tokenizer from "../Tokenizer";
 import { ParserError } from "../errors/ParserError";
 
 export default class Event extends Node {
+  static readonly validDays: string[] = [
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday"
+  ]
   title: string = "";
   repeating: boolean = false;
   daysOfWeek: string[] = [];
@@ -28,7 +37,7 @@ export default class Event extends Node {
     if (token === "every") {
       this.repeating = true;
       token = tokenizer.pop();
-      if (token === null) {
+      if (token === null || !Event.validDays.includes(token)) {
         throw new ParserError(`Error on line ${currentLine}: expected a day of the week`);
       }
       let dayOfWeek: string = token;
@@ -40,20 +49,8 @@ export default class Event extends Node {
         tokenizer.pop();
         currentLine = tokenizer.getLine();
         token = tokenizer.pop();
-        switch (token) {
-          case "Sunday":
-          case "Monday":
-          case "Tuesday":
-          case "Wednesday":
-          case "Thursday":
-          case "Friday":
-          case "Saturday":
-            let dayOfWeek = token;
-            this.daysOfWeek.push(dayOfWeek);
-            token = tokenizer.top();
-            break;
-          default:
-            throw new ParserError(`Error on line ${currentLine}: expected a day of the week`)
+        if (token === null || !Event.validDays.includes(token)) {
+          throw new ParserError(`Error on line ${currentLine}: expected a day of the week`)
         }
       }
     } else if (token === "on") {

--- a/src/ast/Events.ts
+++ b/src/ast/Events.ts
@@ -1,19 +1,35 @@
-class Events extends CalTypes {
-  events: String;
-  calTypes: Array<CalTypes>;
- // name: String; // TODO should be renamed/figure out what to do here
+import Tokenizer from "../Tokenizer";
+import Event from "./Event";
 
-  parse(): void {
+export default class Events extends Node {
+  events: Event[] = [];
+  
+  parse(tokenizer: Tokenizer): void {
+    tokenizer.getAndCheckNext("Events:")
     while (!tokenizer.checkToken("Done")) {
-      let calType: CalType = null;
-      if (tokenizer.checkToken("Events:")) {
-        calType = new Event();
-      }
+      let event: Event = new Event();
+      event.parse(tokenizer);
+      this.events.push(event);
     }
-    calType.parse();
-    calTypes.add(calType);
-    Calendar.createCalendarFile();
+    tokenizer.getAndCheckNext("Done");
   }
 
-  // TODO figure out what to do with typeCheck() and nameCheck() methods
+  evaluate(): void {
+    for (let event of this.events) {
+      event.evaluate();
+    }
+  }
+
+  nameCheck(): void {
+    for (let event of this.events) {
+      event.nameCheck();
+    }
+  }
+
+  typeCheck(): void {
+    for (let event of this.events) {
+      event.typeCheck();
+    }
+  }
+
 }

--- a/src/ast/Events.ts
+++ b/src/ast/Events.ts
@@ -1,17 +1,27 @@
 import Tokenizer from "../Tokenizer";
 import Event from "./Event";
+import Node from "../Node";
+import { ParserError } from "../errors/ParserError";
 
 export default class Events extends Node {
   events: Event[] = [];
   
   parse(tokenizer: Tokenizer): void {
-    tokenizer.getAndCheckNext("Events:")
-    while (!tokenizer.checkToken("Done")) {
+    let currentLine = tokenizer.getLine();
+    let token = tokenizer.pop();
+    if (token !== "Events:") {
+      throw new ParserError(`Error at line ${currentLine}: expected keyword [Events:] but got [${token}]`);
+    }
+    while (tokenizer.top() !== "Done") {
       let event: Event = new Event();
       event.parse(tokenizer);
       this.events.push(event);
     }
-    tokenizer.getAndCheckNext("Done");
+    currentLine = tokenizer.getLine();
+    token = tokenizer.pop()
+    if (token !== "Done") {
+      throw new ParserError(`Error at line ${currentLine}: expected keyword [Done] but got [${token}]`);
+    }
   }
 
   evaluate(): void {

--- a/src/ast/Program.ts
+++ b/src/ast/Program.ts
@@ -1,27 +1,38 @@
 import Node from "../Node";
 import CalTypes from "./CalTypes";
 import Events from "./Events";
-import { tokenizer } from "../Tokenizer";
+import Tokenizer from "../Tokenizer";
 
 export default class Program extends Node {
-  let calTypes = new Array<CalTypes>;
+  calTypes: CalTypes[] = [];
 
-  public parse(): void {
+  parse(tokenizer: Tokenizer): void {
    tokenizer.getAndCheckNext("Start");
    while (!tokenizer.checkToken("End")) {
-     let calType: CalType = null;
+     let calType: CalTypes = null;
      if (tokenizer.checkToken("Events:")) {
        calType = new Events();
      }
+     calType.parse();
+     this.calTypes.push(calType);
    }
-   calType.parse();
-   calTypes.add(calType);
-   Calendar.createCalendarFile();
   }
 
-  public nameCheck(): void {
-    for (let calType of calTypes) {
+  evaluate(): void {
+    for (let calType of this.calTypes) {
+      calType.evaluate();
+    }
+  }
+
+  nameCheck(): void {
+    for (let calType of this.calTypes) {
       calType.nameCheck();
+    }
+  }
+
+  typeCheck(): void {
+    for (let calType of this.calTypes) {
+      calType.typeCheck();
     }
   }
 }


### PR DESCRIPTION
- changed object arrays and maps into primitives
- changed parse() method to take argument of type Tokenizer
- changed Event parse() method to not recurse further down tree but to save dates and times as strings
- added stubs for evaluate(), nameCheck(), and typeCheck() methods
- added types where appropriate