### PR TITLE
Tweaks Tokenizer and Events AST, hooks up main script

### DIFF
--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -43,10 +43,11 @@ export default class Tokenizer {
     });
 
     // Remove extra spacing around each token
-    tokenizedProgram = tokenizedProgram.replace(/[ ]+/g, "");
+    tokenizedProgram = tokenizedProgram.replace(/[ ]{2,}/g, " ");
 
     // Create token list by spliting on underscores
     let tokenList = tokenizedProgram.split(/[_]+/g);
+    tokenList = tokenList.map(token => token.trim());
 
     // Remove first and last items from token list (they are empty strings)
     tokenList = tokenList.slice(1, tokenList.length - 1);

--- a/src/ast/Event.ts
+++ b/src/ast/Event.ts
@@ -11,7 +11,7 @@ export default class Event extends Node {
     "Thursday",
     "Friday",
     "Saturday"
-  ]
+  ];
   title: string = "";
   repeating: boolean = false;
   daysOfWeek: string[] = [];
@@ -27,7 +27,9 @@ export default class Event extends Node {
     let currentLine = tokenizer.getLine();
     let token = tokenizer.pop();
     if (token === null) {
-      throw new ParserError(`Error on line ${currentLine}: expected an event title`);
+      throw new ParserError(
+        `Error on line ${currentLine}: expected an event title`
+      );
     }
     this.title = token;
 
@@ -38,7 +40,9 @@ export default class Event extends Node {
       this.repeating = true;
       token = tokenizer.pop();
       if (token === null || !Event.validDays.includes(token)) {
-        throw new ParserError(`Error on line ${currentLine}: expected a day of the week`);
+        throw new ParserError(
+          `Error on line ${currentLine}: expected a day of the week`
+        );
       }
       let dayOfWeek: string = token;
       this.daysOfWeek.push(dayOfWeek);
@@ -50,7 +54,9 @@ export default class Event extends Node {
         currentLine = tokenizer.getLine();
         token = tokenizer.pop();
         if (token === null || !Event.validDays.includes(token)) {
-          throw new ParserError(`Error on line ${currentLine}: expected a day of the week`)
+          throw new ParserError(
+            `Error on line ${currentLine}: expected a day of the week`
+          );
         }
       }
     } else if (token === "on") {
@@ -62,7 +68,9 @@ export default class Event extends Node {
       }
       this.date = token;
     } else {
-      throw new ParserError(`Error on line ${currentLine}: expected keyword [every] or [on] but got [${token}]`);
+      throw new ParserError(
+        `Error on line ${currentLine}: expected keyword [every] or [on] but got [${token}]`
+      );
     }
 
     // Get what should be the start and end time of the event
@@ -75,36 +83,42 @@ export default class Event extends Node {
       currentLine = tokenizer.getLine();
       token = tokenizer.pop();
       if (token === null) {
-        throw new ParserError(`Error on line ${currentLine}: expected a start time`);
+        throw new ParserError(
+          `Error on line ${currentLine}: expected a start time`
+        );
       }
       this.fromTime = token;
       currentLine = tokenizer.getLine();
       token = tokenizer.pop();
       if (token !== "to") {
-        throw new ParserError(`Error on line ${currentLine}: expected keyword [to] but got [${token}]`);
+        throw new ParserError(
+          `Error on line ${currentLine}: expected keyword [to] but got [${token}]`
+        );
       }
       currentLine = tokenizer.getLine();
       token = tokenizer.pop();
       if (token === null) {
-        throw new ParserError(`Error on line ${currentLine}: expected a start time`);
+        throw new ParserError(
+          `Error on line ${currentLine}: expected a start time`
+        );
       }
       this.toTime = token;
     } else {
-      throw new ParserError(`Error on line ${currentLine}: expected keyword [all day] or [from] but got [${token}]`);
+      throw new ParserError(
+        `Error on line ${currentLine}: expected keyword [all day] or [from] but got [${token}]`
+      );
     }
 
     // stub for locations
     currentLine = tokenizer.getLine();
     token = tokenizer.top();
     if (token === "at") {
-      
     }
 
     // stub for guests
     currentLine = tokenizer.getLine();
     token = tokenizer.top();
     if (token === "with") {
-      
     }
   }
 

--- a/src/ast/Events.ts
+++ b/src/ast/Events.ts
@@ -5,12 +5,14 @@ import { ParserError } from "../errors/ParserError";
 
 export default class Events extends Node {
   events: Event[] = [];
-  
+
   parse(tokenizer: Tokenizer): void {
     let currentLine = tokenizer.getLine();
     let token = tokenizer.pop();
     if (token !== "Events:") {
-      throw new ParserError(`Error at line ${currentLine}: expected keyword [Events:] but got [${token}]`);
+      throw new ParserError(
+        `Error at line ${currentLine}: expected keyword [Events:] but got [${token}]`
+      );
     }
     while (tokenizer.top() !== "Done") {
       let event: Event = new Event();
@@ -18,10 +20,14 @@ export default class Events extends Node {
       this.events.push(event);
     }
     currentLine = tokenizer.getLine();
-    token = tokenizer.pop()
+    token = tokenizer.pop();
     if (token !== "Done") {
-      throw new ParserError(`Error at line ${currentLine}: expected keyword [Done] but got [${token}]`);
+      throw new ParserError(
+        `Error at line ${currentLine}: expected keyword [Done] but got [${token}]`
+      );
     }
+
+    console.log("Events:", this.events);
   }
 
   evaluate(): void {
@@ -41,5 +47,4 @@ export default class Events extends Node {
       event.typeCheck();
     }
   }
-
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,10 @@
-// import Program from "./ast/Program";
+import Program from "./ast/Program";
 import Tokenizer from "./Tokenizer";
 
 let tokenizer = new Tokenizer("./inputs/valid_simple.cal");
-// let program = new Program();
+let program = new Program();
 
-// program.parse(tokenizer);
+program.parse(tokenizer);
 // program.nameCheck();
 // program.typeCheck();
 // program.evaluate();


### PR DESCRIPTION
1. Logs out the Events object after parsing
2. Enables program parsing in main file
3. Tokenizer now preserves spacing between words
<img width="715" alt="Screen Shot 2019-10-06 at 11 43 34 PM" src="https://user-images.githubusercontent.com/1896810/66290181-698a0400-e893-11e9-9cf6-471d6e312bc8.png">
