### PR TITLE
Change token keyword literals to use enum of constants

### DIFF
--- a/src/TokenKeywords.ts
+++ b/src/TokenKeywords.ts
@@ -1,0 +1,16 @@
+export enum TokenKeywords {
+    START = "Start",
+    EVENTS = "Events:",
+    LOCATIONS = "Locations:",
+    GUESTS = "Guests",
+    EVERY = "every",
+    AND = "and",
+    ON = "on",
+    ALL_DAY = "all day",
+    FROM = "from",
+    TO = "to",
+    AT = "at",
+    WITH = "with",
+    DONE = "Done",
+    END = "End"
+}

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -1,22 +1,10 @@
 import * as fs from "fs";
 import * as path from "path";
 import { ParserError } from "./errors/ParserError";
+import { TokenKeywords } from "./TokenKeywords";
 
 export default class Tokenizer {
   program: string;
-  literals: Array<string> = [
-    "Start",
-    "Events:",
-    "every",
-    "and",
-    "on",
-    "all day",
-    "from",
-    "at",
-    "with",
-    "Done",
-    "End"
-  ];
   tokens: string[] = [];
   currentTokenIdx: number = 0;
   line: number = 1;
@@ -38,7 +26,7 @@ export default class Tokenizer {
     let tokenizedProgram = this.program.replace(/\r?\n|\r/g, "_NEWLINE_");
 
     // Add underscores around each literal
-    this.literals.forEach(literal => {
+    Object.values(TokenKeywords).forEach(literal => {
       tokenizedProgram = tokenizedProgram.replace(literal, `_${literal}_`);
     });
 

--- a/src/ast/Event.ts
+++ b/src/ast/Event.ts
@@ -1,6 +1,7 @@
 import Node from "../Node";
 import Tokenizer from "../Tokenizer";
 import { ParserError } from "../errors/ParserError";
+import { TokenKeywords } from "../TokenKeywords";
 
 export default class Event extends Node {
   static readonly validDays: string[] = [
@@ -36,7 +37,7 @@ export default class Event extends Node {
     // Get what should be the date of the event
     currentLine = tokenizer.getLine();
     token = tokenizer.pop();
-    if (token === "every") {
+    if (token === TokenKeywords.EVERY) {
       this.repeating = true;
       token = tokenizer.pop();
       if (token === null || !Event.validDays.includes(token)) {
@@ -49,7 +50,7 @@ export default class Event extends Node {
       token = tokenizer.top();
       // loop over ("and" DAYOFWEEK)* tokens
       // TODO: clean this up
-      while (token === "and") {
+      while (token === TokenKeywords.AND) {
         tokenizer.pop();
         currentLine = tokenizer.getLine();
         token = tokenizer.pop();
@@ -59,7 +60,7 @@ export default class Event extends Node {
           );
         }
       }
-    } else if (token === "on") {
+    } else if (token === TokenKeywords.ON) {
       this.repeating = false;
       currentLine = tokenizer.getLine();
       token = tokenizer.pop();
@@ -69,16 +70,16 @@ export default class Event extends Node {
       this.date = token;
     } else {
       throw new ParserError(
-        `Error on line ${currentLine}: expected keyword [every] or [on] but got [${token}]`
+        `Error on line ${currentLine}: expected keyword [${TokenKeywords.EVERY}] or [${TokenKeywords.ON}] but got [${token}]`
       );
     }
 
     // Get what should be the start and end time of the event
     currentLine = tokenizer.getLine();
     token = tokenizer.pop();
-    if (token === "all day") {
+    if (token === TokenKeywords.ALL_DAY) {
       this.allDay = true;
-    } else if (token === "from") {
+    } else if (token === TokenKeywords.FROM) {
       this.allDay = false;
       currentLine = tokenizer.getLine();
       token = tokenizer.pop();
@@ -90,35 +91,35 @@ export default class Event extends Node {
       this.fromTime = token;
       currentLine = tokenizer.getLine();
       token = tokenizer.pop();
-      if (token !== "to") {
+      if (token !== TokenKeywords.TO) {
         throw new ParserError(
-          `Error on line ${currentLine}: expected keyword [to] but got [${token}]`
+          `Error on line ${currentLine}: expected keyword [${TokenKeywords.TO}] but got [${token}]`
         );
       }
       currentLine = tokenizer.getLine();
       token = tokenizer.pop();
       if (token === null) {
         throw new ParserError(
-          `Error on line ${currentLine}: expected a start time`
+          `Error on line ${currentLine}: expected an end time`
         );
       }
       this.toTime = token;
     } else {
       throw new ParserError(
-        `Error on line ${currentLine}: expected keyword [all day] or [from] but got [${token}]`
+        `Error on line ${currentLine}: expected keyword [${TokenKeywords.ALL_DAY}] or [${TokenKeywords.FROM}] but got [${token}]`
       );
     }
 
     // stub for locations
     currentLine = tokenizer.getLine();
     token = tokenizer.top();
-    if (token === "at") {
+    if (token === TokenKeywords.AT) {
     }
 
     // stub for guests
     currentLine = tokenizer.getLine();
     token = tokenizer.top();
-    if (token === "with") {
+    if (token === TokenKeywords.WITH) {
     }
   }
 

--- a/src/ast/Events.ts
+++ b/src/ast/Events.ts
@@ -2,6 +2,7 @@ import Tokenizer from "../Tokenizer";
 import Event from "./Event";
 import Node from "../Node";
 import { ParserError } from "../errors/ParserError";
+import { TokenKeywords } from "../TokenKeywords";
 
 export default class Events extends Node {
   events: Event[] = [];
@@ -9,21 +10,21 @@ export default class Events extends Node {
   parse(tokenizer: Tokenizer): void {
     let currentLine = tokenizer.getLine();
     let token = tokenizer.pop();
-    if (token !== "Events:") {
+    if (token !== TokenKeywords.EVENTS) {
       throw new ParserError(
-        `Error at line ${currentLine}: expected keyword [Events:] but got [${token}]`
+        `Error at line ${currentLine}: expected keyword [${TokenKeywords.EVENTS}] but got [${token}]`
       );
     }
-    while (tokenizer.top() !== "Done") {
+    while (tokenizer.top() !== TokenKeywords.DONE) {
       let event: Event = new Event();
       event.parse(tokenizer);
       this.events.push(event);
     }
     currentLine = tokenizer.getLine();
     token = tokenizer.pop();
-    if (token !== "Done") {
+    if (token !== TokenKeywords.DONE) {
       throw new ParserError(
-        `Error at line ${currentLine}: expected keyword [Done] but got [${token}]`
+        `Error at line ${currentLine}: expected keyword [${TokenKeywords.DONE}] but got [${token}]`
       );
     }
 

--- a/src/ast/Program.ts
+++ b/src/ast/Program.ts
@@ -2,6 +2,7 @@ import Node from "../Node";
 import Events from "./Events";
 import Tokenizer from "../Tokenizer";
 import { ParserError } from "../errors/ParserError";
+import { TokenKeywords } from "../TokenKeywords";
 
 export default class Program extends Node {
   nodes: Node[] = [];
@@ -10,14 +11,14 @@ export default class Program extends Node {
     // we might be able to get rid of the [Start] and [End] tokens by just relying on the tokenizer.hasNext() method?
     let currentLine = tokenizer.getLine();
     let token = tokenizer.pop();
-    if (token !== "Start") {
-      throw new ParserError(`Error at line ${currentLine}: expected keyword [Start] but got [${token}]`);
+    if (token !== TokenKeywords.START) {
+      throw new ParserError(`Error at line ${currentLine}: expected keyword [${TokenKeywords.START}] but got [${token}]`);
     }
-    while (tokenizer.top() !== "End") {
+    while (tokenizer.top() !== TokenKeywords.END) {
       currentLine = tokenizer.getLine();
       token = tokenizer.top();
       switch (token) {
-        case "Events:":
+        case TokenKeywords.EVENTS:
           let events = new Events();
           events.parse(tokenizer);
           this.nodes.push(events);
@@ -28,8 +29,8 @@ export default class Program extends Node {
     }
     currentLine = tokenizer.getLine();
     token = tokenizer.pop();
-    if (token !== "End") {
-      throw new ParserError(`Error at line ${currentLine}: expected keyword [End] but got [${token}]`);
+    if (token !== TokenKeywords.END) {
+      throw new ParserError(`Error at line ${currentLine}: expected keyword [${TokenKeywords.START}] but got [${token}]`);
     }
   }
 


### PR DESCRIPTION
- create enum TokenKeywords to hold string keyword constants
- change tokenizer to iterate over TokenKeyword values to mark with underscores
- change AST node checks to compare token values to TokenKeyword constants